### PR TITLE
fix: correct PostCSS plugin configuration

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,7 +1,7 @@
-import tailwindcss from "@tailwindcss/postcss";
-
 const config = {
-  plugins: [tailwindcss],
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- fix PostCSS config to load Tailwind plugin by name to avoid malformed configuration errors

## Testing
- `npm run build` *(fails: Route "src/app/api/payouts/[id]/release/route.ts" has an invalid "POST" export: Type "{ params: { id: string; }; }" is not a valid type for the function's second argument)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0b9f834ac83258ac1ea0ff4de4f1c